### PR TITLE
Add some custom security and configuration adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ postgresql_databases:
     uuid_ossp: yes      # flag to install the uuid-ossp extension on this database (yes/no)
     citext: yes         # flag to install the citext extension on this database (yes/no)
     encoding: "UTF-8"   # override global {{ postgresql_encoding }} variable per database
-    state: "present"    # optional; one of 'present', 'absent', 'dump', 'restore'
     lc_collate: "en_GB.UTF-8"   # override global {{ postgresql_locale }} variable per database
     lc_ctype: "en_GB.UTF-8"     # override global {{ postgresql_ctype }} variable per database
 
@@ -120,18 +119,15 @@ postgresql_users:
   - name: baz
     pass: pass
     encrypted: yes  # if password should be encrypted, postgresql >= 10 does only accepts encrypted passwords
-    state: "present"    # optional; one of 'present', 'absent'
 
 # List of schemas to be created (optional)
 postgresql_database_schemas:
   - database: foobar           # database name
     schema: acme               # schema name
-    state: present
 
   - database: foobar           # database name
     schema: acme_baz           # schema name
     owner: baz                 # owner name
-    state: present
 
 # List of user privileges to be applied (optional)
 postgresql_user_privileges:

--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ postgresql_database_schemas:
 
 # List of user privileges to be applied (optional)
 postgresql_user_privileges:
-  - name: baz                   # user name
-    db: foobar                  # database
-    priv: "ALL"                 # privilege string format: example: INSERT,UPDATE/table:SELECT/anothertable:ALL
-    role_attr_flags: "CREATEDB" # role attribute flags
+  - roles: baz                  # comma separated list of role (user/group) names to set permissions for.
+    database: foobar            # name of database to connect to.
+    schema: acme_baz            # schema that contains the database objects specified via objs (see documentation for details).
+    type: table                 # type of database object to set privileges on. e.g.: table (default), sequence, function,... (see documentation for details)
+    objs: employee              # comma separated list of database objects to set privileges on (see documentation for details).
+    privs: "ALL"                # comma separated list of privileges to grant. e.g.: INSERT,UPDATE/ALL/USAGE
 ```
 
 There's a lot more knobs and bolts to set, which you can find in the [defaults/main.yml](./defaults/main.yml)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ postgresql_service_enabled: false # should the service be enabled, default is tr
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false
 
+postgresql_log_directory_group: "{{ postgresql_service_group }}" # group of the `postgresql_log_directory`.
+postgresql_log_directory_mode: 0700 # permissions of the `postgresql_log_directory`.
+
 # List of databases to be created (optional)
 # Note: for more flexibility with extensions use the postgresql_database_extensions setting.
 postgresql_databases:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ postgresql_admin_user: "postgres"
 postgresql_default_auth_method: "peer"
 
 postgresql_service_enabled: false # should the service be enabled, default is true
+postgresql_service_restarted_state: "reloaded" # state of the service after configuration changes (e.g. restarted, reloaded).
 
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -475,6 +475,10 @@ postgresql_logging_collector:          off
 # These are only used if logging_collector is on:
 # Directory where log files are written, can be absolute or relative to PGDATA
 postgresql_log_directory:              "pg_log"
+# Group of the `postgresql_log_directory.
+postgresql_log_directory_group: "{{ postgresql_service_group }}"
+# permissions of the `postgresql_log_directory`.
+postgresql_log_directory_mode: 0700
 # Log file name pattern, can include strftime() escapes
 postgresql_log_filename:               "postgresql-%Y-%m-%d_%H%M%S.log"
 postgresql_log_file_mode:              "0600" # begin with 0 to use octal notation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ postgresql_service_user: "{{ postgresql_admin_user }}"
 postgresql_service_user_pgsql_profile: false
 postgresql_service_group: "{{ postgresql_admin_user }}"
 postgresql_service_enabled: true
+postgresql_service_restarted_state: "reloaded"
 
 postgresql_cluster_name: "main"
 postgresql_cluster_reset: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
   - name: restart postgresql
     service:
       name: "{{ postgresql_service_name }}"
-      state: restarted
+      state: "{{ postgresql_service_restarted_state }}"
       enabled: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,6 +52,7 @@
     - "{{ postgresql_locale }}"
     - "{{ postgresql_ctype }}"
   when: ansible_os_family == "Debian" and item != "C.UTF-8"
+  notify: restart postgresql
 
 - name: PostgreSQL | Ensure the locale is generated | RedHat
   become: yes
@@ -62,6 +63,9 @@
     - { parts: "{{ postgresql_ctype_parts }}", locale_name: "{{ postgresql_ctype }}" }
   when: ansible_os_family == "RedHat"
   ignore_errors: yes
+  notify: restart postgresql
+
+- meta: flush_handlers
 
 - name: PostgreSQL | Stop PostgreSQL | Debian
   service:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -39,9 +39,9 @@
   file:
     path: "{{ postgresql_log_directory }}"
     owner: "{{ postgresql_service_user }}"
-    group: "{{ postgresql_service_group }}"
+    group: "{{ postgresql_log_directory_group }}"
     state: directory
-    mode: 0700
+    mode: "{{ postgresql_log_directory_mode }}"
   register: pglog_dir_exist
   when: postgresql_log_directory != "pg_log"
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -14,7 +14,7 @@
     lc_ctype: "{{ item.lc_ctype | default(postgresql_ctype) }}"
     port: "{{postgresql_port}}"
     template: "template0"
-    state: "{{ item.state | default('present') }}"
+    state: "present"
     login_user: "{{postgresql_admin_user}}"
   become: yes
   become_user: "{{postgresql_admin_user}}"

--- a/tasks/schemas.yml
+++ b/tasks/schemas.yml
@@ -9,7 +9,7 @@
     login_password: "{{ item.password | default(omit) }}"
     login_user: "{{ postgresql_admin_user }}"
     port: "{{ postgresql_port }}"
-    state: "{{ item.state | default('present') }}"
+    state: "present"
   become: yes
   become_user: "{{ postgresql_admin_user }}"
   with_items: "{{ postgresql_database_schemas }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -11,7 +11,7 @@
     password: "{{ item.pass | default(omit) }}"
     encrypted: "{{ item.encrypted | default(omit) }}"
     port: "{{postgresql_port}}"
-    state: "{{ item.state | default('present') }}"
+    state: "present"
     login_user: "{{postgresql_admin_user}}"
   no_log: true
   become: yes

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -1,12 +1,15 @@
 # file: postgresql/tasks/users_privileges.yml
 
 - name: PostgreSQL | Update the user privileges
-  postgresql_user:
-    name: "{{item.name}}"
-    db: "{{item.db | default(omit)}}"
-    port: "{{postgresql_port}}"
-    priv: "{{item.priv | default(omit)}}"
+  postgresql_privs:
+    roles: "{{item.roles}}"
+    database: "{{item.database | default(omit)}}"
+    schema: "{{item.schema | default(omit)}}"
+    type: "{{item.type | default(omit)}}"
+    objs: "{{item.objs | default(omit)}}"
+    privs: "{{item.privs | default(omit)}}"
     state: present
+    port: "{{postgresql_port}}"
     login_host: "{{item.host | default(omit)}}"
     login_user: "{{postgresql_admin_user}}"
     role_attr_flags: "{{item.role_attr_flags | default(omit)}}"

--- a/tests/docker/group_vars/postgresql.yml
+++ b/tests/docker/group_vars/postgresql.yml
@@ -35,8 +35,8 @@ postgresql_database_schemas:
     owner: baz
 
 postgresql_user_privileges:
-  - name: baz
-    db: foobar
+  - roles: baz
+    database: foobar
 
 postgresql_ext_install_contrib: true
 

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -32,8 +32,8 @@ postgresql_users:
   - name: zabaz
 
 postgresql_user_privileges:
-  - name: baz
-    db: foobar
+  - roles: baz
+    database: foobar
 
 postgresql_database_schemas:
   - database: foobar

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 # PostgreSQL vars for Debian based distributions
 
-postgresql_service_name: "postgresql"
+postgresql_service_name: "postgresql@{{ postgresql_version }}-{{ postgresql_cluster_name }}"
 
 postgresql_bin_directory: /usr/bin
 


### PR DESCRIPTION
## Description
1. [Allow to override log dir permissions and group](https://github.com/mediapart/ansible-postgresql/pull/1/commits/8be74967f55fed3d12ea1b4ba4a049a1d3be4c6f): sometimes (and this is our case) it's useful to be able to define on the log_directory different group and permissions than the current default values that are postgres for group, and 0700 for permissions. Regarding the group, note that it's already possible to define a different group, but we don't want to use the postgresql_group already existing fact because we only want to change the log directory group, not the group for all files used by postgres (data directory, socket, config files, ...).
2. [Restart postgres after locales generation](https://github.com/mediapart/ansible-postgresql/pull/1/commits/93d0335bce8ce2a1e3ef73872fb0b3674aaf632f): without this restart, trying to create a database using a charset related to the new locale leads to an error.
3. [Prevent users, databases and schemas deletion](https://github.com/mediapart/ansible-postgresql/pull/1/commits/8656a6e0fd1c3fc6cce9c1fe908af946327dd033): ansible `state` attribute of these objects is always set to "present".
4. [Allow to prevent postgresql restart after configuration changes](https://github.com/mediapart/ansible-postgresql/pull/1/commits/1aaa18cfa6a6cb16ebf41b754b29bdeb539e44d0) on some environments such as production. On these environments we prefer to handle outside of ansible the restarts if needed by some configuration changes.
5. [Fix debian postgresql service name on debian](https://github.com/mediapart/ansible-postgresql/pull/1/commits/95860d79ed17fd1fb4a62b863e3e81c257f57439) to avoid the non-transmission of some actions to the systemd service.
6. [Fix postgresql_user priv argument deprecation](https://github.com/mediapart/ansible-postgresql/pull/1/commits/c93cf6780227c53afd2f34218f8e2561aef2c87f) by using `postgresql_privs` module instead of the `priv` argument of `postgresql_user` module.

## Tests
1. In our case, validate that another user belonging to the defined group is able to read the current postgres log file, and thanks to the `setgid` (`postgresql_log_dir_mode: 02750`), the new log files created in the log directory.
2. Verify that we can create a database using a charset bound to a new locale without error (on environments where we allow restarting postgres).
3. Try to add `state: absent` for example on an existing test database and check it has no effect.
4. Check that an ansible run, changing the postgres configuration, never restarts postgres on a "protected" environment.
5. Make sure the postgresql server is stopped/started/restarted/reloaded in all the different ansible tasks that need to perform these actions.
6. On a test database, revoke existing users privileges previously created using `postgresql_user`, then recreate them with `postgresql_privs`, and validate that there is no regression.
