### PR TITLE
Reload or restart postgres in case of configuration change

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -240,7 +240,8 @@
   - name: PostgreSQL | Reload PostgreSQL configuration
     service:
       name: "{{ postgresql_service_name }}"
-      state: reloaded
+      # TODO improve "need restart" detection
+      state: "{{ postgresql_service_restarted_state }}"
     register: postgresql_reloaded
     when: not postgresql_cold_started.changed
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed


### PR DESCRIPTION
## Description

On non-prd environments we can accept to restart postgresql in all cases if configuration has changed.

In a better and future version, we could split and improve the reload or restart task in order to:
- continue to never restart on prd through the handler
- on non-prd, restart depending on the changed file and parameter (e.g: pg_hba.conf file doesn't require restart, and only some postgresql.conf parameters require a restart).

## Tests
Already tested on `int` :heavy_check_mark: 