### PR TITLE
Fix role attributes (role_attr_flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ postgresql_users:
   - name: baz
     pass: pass
     encrypted: yes  # if password should be encrypted, postgresql >= 10 does only accepts encrypted passwords
+    role_attr_flags: "login" # comma separated list of role attributes ([no]superuser,[no]createrole,[no]createdb,[no]inherit,[no]login,[no]replication,[no]bypassrls,)
 
 # List of schemas to be created (optional)
 postgresql_database_schemas:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,6 +12,7 @@
     encrypted: "{{ item.encrypted | default(omit) }}"
     port: "{{postgresql_port}}"
     state: "present"
+    role_attr_flags: "{{item.role_attr_flags | default(omit)}}"
     login_user: "{{postgresql_admin_user}}"
   no_log: "{{ postgresql_hide_passwords }}"
   become: yes

--- a/tasks/users_privileges.yml
+++ b/tasks/users_privileges.yml
@@ -12,7 +12,6 @@
     port: "{{postgresql_port}}"
     login_host: "{{item.host | default(omit)}}"
     login_user: "{{postgresql_admin_user}}"
-    role_attr_flags: "{{item.role_attr_flags | default(omit)}}"
   become: yes
   become_user: "{{postgresql_admin_user}}"
   with_items: "{{postgresql_user_privileges}}"


### PR DESCRIPTION
## Description

Bug introduced in c93cf67 when trying to fix postgresql_user priv argument deprecation.

Indeed, `role_attr_flags` is not a parameter of postgresql_privs module but of the [postgresql_user](https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_user_module.html#parameter-role_attr_flags) module.

## Test
Already done:
- without this fix => error when trying to add attributes to role (e.g: nologin,nocreatedb,...)
- with this fix => no error