### PR TITLE
Bump postgresql 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ An example how to include this role as a task:
 
 #### Compatibility matrix
 
-| Distribution / PostgreSQL |     11     |         12         |         13         |         14         |         15         |       16        |
-| ------------------------- | :--------: | :----------------: | :----------------: | :----------------: | :----------------: | :-------------: |
-| Debian 11.x               | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Debian 12.x               | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Rockylinux 8.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Rockylinux 9.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Ubuntu 20.04.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Ubuntu 22.04.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Distribution / PostgreSQL |     11     |         12         |         13         |         14         |         15         |         16         |         17         |
+| ------------------------- | :--------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Debian 11.x               | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
+| Debian 12.x               | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
+| Rockylinux 8.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
+| Rockylinux 9.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
+| Ubuntu 20.04.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
+| Ubuntu 22.04.x            | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |    :interrobang:   |
 
 
 - :white_check_mark: - tested, works fine
@@ -75,7 +75,7 @@ An example how to include this role as a task:
 
 ```yaml
 # Basic settings
-postgresql_version: 16
+postgresql_version: 17
 postgresql_encoding: "UTF-8"
 postgresql_locale: "en_US.UTF-8"
 postgresql_ctype: "en_US.UTF-8"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # file: postgresql/defaults/main.yml
 
 # Basic settings
-postgresql_version: 16
+postgresql_version: 17
 postgresql_version_terse: "{{ postgresql_version | replace('.', '') }}"  # Short version of the postgresql_version, used in some path and filenames
 postgresql_encoding: "UTF-8"
 postgresql_data_checksums: false
@@ -49,6 +49,7 @@ postgresql_postgis_release_compatibility:
   14: "3.2"
   15: "3.2"
   16: "3.4"
+  17: "3.5"
 
 postgresql_ext_postgis_version: "{{ postgresql_postgis_release_compatibility.get(postgresql_version) }}"
 postgresql_ext_postgis_version_terse: "{{ postgresql_ext_postgis_version | replace('.','') }}"
@@ -153,7 +154,7 @@ postgresql_client_connection_check_interval: 0            # (>= 14)
 postgresql_authentication_timeout: 60s # 1s-600s
 postgresql_password_encryption: "{{ 'scram-sha-256' if postgresql_version is version_compare('14', '>=') else 'md5' }}" # (>=14.0 set to scram-sha-256 for best security)
 posgresql_scram_iterations: 4096 # (>= 16)
-postgresql_db_user_namespace: off
+postgresql_db_user_namespace: off # (<= 16)
 
 # GSSAPI using Kerberos
 postgresql_krb_server_keyfile: "{{ 'FILE:${sysconfdir}/krb5.keytab' if postgresql_version is version_compare('14', '>=') else '' }}"
@@ -198,9 +199,9 @@ postgresql_max_prepared_transactions: 0 # zero disables the feature
 # you actively intend to use prepared transactions.
 postgresql_work_mem:                   4MB      # min 64kB
 postgresql_hash_mem_multiplier:        "{{ 2.0 if postgresql_version is version_compare('15', '>=') else 1.0 }}" # (>= 13)
-postgresql_maintenance_work_mem:       64MB     # min 1MB
+postgresql_maintenance_work_mem:       64MB     # min 1MB, (>= 17) min 64kB
 postgresql_replacement_sort_tuples:    150000   # (>= 9.6) limits use of replacement selection sort
-postgresql_autovacuum_work_mem:        -1       # min 1MB, or -1 to use maintenance_work_mem
+postgresql_autovacuum_work_mem:        -1       # min 1MB, (>= 17) min 64kB, or -1 to use maintenance_work_mem
 postgresql_logical_decoding_work_mem:  64MB     # (>= 13)
 postgresql_max_stack_depth:            2MB      # min 100kB
 postgresql_shared_memory_type:         "mmap"   # (>= 12)
@@ -213,14 +214,26 @@ postgresql_dynamic_shared_memory_type: "posix"  # the default is the first optio
                                                 #   mmap
                                                 # use none to disable dynamic shared memory
 postgresql_min_dynamic_shared_memory: 0MB       # (>= 14) (change requires restart)
-postgres_vacuum_buffer_usage_limit: 256kB       # (>= 16) size of vacuum and analyze buffer access strategy ring;
+postgres_vacuum_buffer_usage_limit: "{{ '2MB' if postgresql_version is version_compare('17', '>=') else '256kB' }}" # (>= 16) size of vacuum and analyze buffer access strategy ring;
                                                 # 0 to disable vacuum buffer access strategy;
                                                 # range 128kB to 16GB
+
+# SLRU buffers (change requires restart)
+postgresql_commit_timestamp_buffers: 0          # (>= 17) memory for pg_commit_ts (0 = auto)
+postgresql_multixact_offset_buffers: 16         # (>= 17) memory for pg_multixact/offsets
+postgresql_multixact_member_buffers: 32         # (>= 17) memory for pg_multixact/members
+postgresql_notify_buffers: 16                   # (>= 17) memory for pg_notify
+postgresql_serializable_buffers: 32             # (>= 17) memory for pg_serial
+postgresql_subtransaction_buffers: 0            # (>= 17) memory for pg_subtrans (0 = auto)
+postgresql_transaction_buffers: 0               # (>= 17) memory for pg_xact (0 = auto)
 
 # - Disk -
 
 # limits per-process temp file space in kB, or -1 for no limit (>= 9.2)
 postgresql_temp_file_limit: -1
+
+# limits the number of SLRU pages allocated for NOTIFY / LISTEN queue (>= 17)
+postgresql_max_notify_queue_pages: 1048576
 
 # - Kernel Resources -
 
@@ -243,16 +256,17 @@ postgresql_bgwriter_flush_after:    512kB  # measured in pages, 0 disables
 
 # - Asynchronous Behavior -
 
-postgresql_backend_flush_after:              0   # (>= 9.6) 0 disables, default is 0
-postgresql_effective_io_concurrency:         1   # 1-1000; 0 disables prefetching
-postgresql_maintenance_io_concurrency:       10  # (>= 13)
-postgresql_max_worker_processes:             8   # (change requires restart)
-postgresql_max_parallel_workers_per_gather:  2   # (>= 9.6) taken from max_worker_processes
-postgresql_max_parallel_maintenance_workers: 2   # (>= 11) taken from max_parallel_workers
-postgresql_max_parallel_workers:             8   # (>= 10)
-postgresql_parallel_leader_participation:    on  # (>= 11)
-postgresql_old_snapshot_threshold:           -1  # (>= 9.6) 1min-60d; -1 disables; 0 is immediate
-                                                 # (change requires restart)
+postgresql_backend_flush_after:              0      # (>= 9.6) 0 disables, default is 0
+postgresql_effective_io_concurrency:         1      # 1-1000; 0 disables prefetching
+postgresql_maintenance_io_concurrency:       10     # (>= 13)
+postgresql_io_combine_limit:                 128kB  # (>= 17) usually 1-32 blocks (depends on OS)
+postgresql_max_worker_processes:             8      # (change requires restart)
+postgresql_max_parallel_workers_per_gather:  2      # (>= 9.6) limited by max_parallel_workers
+postgresql_max_parallel_maintenance_workers: 2      # (>= 11) limited by max_parallel_workers
+postgresql_max_parallel_workers:             8      # (>= 10)
+postgresql_parallel_leader_participation:    on     # (>= 11)
+postgresql_old_snapshot_threshold:           -1     # (>= 9.6 and <= 16) 1min-60d; -1 disables; 0 is immediate
+                                                    # (change requires restart)
 
 #------------------------------------------------------------------------------
 # WRITE-AHEAD LOG
@@ -321,6 +335,12 @@ postgresql_recovery_target_inclusive: ""           # (>= 12)
 postgresql_recovery_target_timeline: "latest"      # (>= 12)
 postgresql_recovery_target_action: "pause"         # (>= 12)
 
+# - WAL Summarization -
+
+postgresql_summarize_wal: off                      # (>= 17) run WAL summarizer process?
+postgresql_wal_summary_keep_time: "10d"            # (>= 17) when to remove old summary files, 0 = never
+
+
 #------------------------------------------------------------------------------
 # REPLICATION
 #------------------------------------------------------------------------------
@@ -344,6 +364,8 @@ postgresql_track_commit_timestamp: off # (>= 9.5)
 postgresql_synchronous_standby_names: [] # '*' means 'all'
 postgresql_synchronous_standby_num_sync: "" # >= 9.6 (NOTE: If you use the ANY/ALL syntax in v10, then note the new variable below)
 postgresql_synchronous_standby_choose_sync: "FIRST" # >= 10
+# streaming replication standby server slot names that logical walsender processes will wait for (>= 17)
+postgresql_synchronized_standby_slots: ""
 # number of xacts by which cleanup is delayed
 postgresql_vacuum_defer_cleanup_age: 0 # (<= 15)
 
@@ -368,6 +390,7 @@ postgresql_wal_receiver_timeout: 60s
 # time to wait before retrying to retrieve WAL after a failed attempt
 postgresql_wal_retrieve_retry_interval: 5s # (>= 9.5)
 postgresql_recovery_min_apply_delay: 0             # (>= 12)
+postgresql_sync_replication_slots: off # (>= 17) enables slot synchronization on the physical standby from the primary
 
 # - Subscribers - (>= 10)
 # These settings are ignored on a publisher.
@@ -401,6 +424,7 @@ postgres_enable_presorted_aggregate:       on    # (>= 16)
 postgresql_enable_seqscan:                 on
 postgresql_enable_sort:                    on
 postgresql_enable_tidscan:                 on
+postgresql_enable_group_by_reordering:     on    # (>= 17)
 
 # - Planner Cost Constants -
 postgresql_seq_page_cost:              1.0     # measured on an arbitrary scale
@@ -669,6 +693,7 @@ postgresql_default_transaction_deferrable: off
 postgresql_session_replication_role:       "origin"
 
 postgresql_statement_timeout:                     0           # in milliseconds, 0 is disabled
+postgresql_transaction_timeout:                   0           # in milliseconds, 0 is disabled (>= 17)
 postgresql_lock_timeout:                          0           # in milliseconds, 0 is disabled (>= 9.3)
 postgresql_idle_in_transaction_session_timeout:   0           # in milliseconds, 0 is disabled (>= 9.6)
 postgresql_idle_session_timeout:                  0           # in milliseconds, 0 is disabled (>= 14)
@@ -684,6 +709,7 @@ postgresql_xmlbinary:    "base64"
 postgresql_xmloption:    "content"
 postgresql_gin_pending_list_limit: 4MB  # (>= 9.5)
 postgresql_createrole_self_grant: '' # (>= 16) 'set', 'inherit' or 'set, inherit'
+postgresql_event_triggers: on # (>= 17)
 
 # - Locale and Formatting -
 
@@ -772,6 +798,7 @@ postgresql_sql_inheritance:             on # (<= 9.6)
 # - Other Platforms and Clients -
 
 postgresql_transform_null_equals:       off
+postgresql_allow_alter_system:          on # (>= 17)
 
 #------------------------------------------------------------------------------
 # ERROR HANDLING

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -7,7 +7,7 @@ This directory is the home of the test playbooks:
 
 ## Molecule
 
-The default tested versions are postgresql 12, 13, 14, 15 and 16 on Debian 11. Linting is disabled for the tests.
+The default tested versions are postgresql 12, 13, 14, 15, 16 and 17? on Debian 11. Linting is disabled for the tests.
 
 The default distribution is ubuntu2204. You can override th with setting the environment variable MOLECULE_DISTRO to one of:
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -48,6 +48,14 @@ platforms:
     pre_build_image: true
     cgroupns_mode: host
     command: ${MOLECULE_DOCKER_COMMAND:-""}
+  - name: postgresql-17
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+    cgroupns_mode: host
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
 provisioner:
   name: ansible
   config_options:

--- a/templates/postgresql.conf-17.j2
+++ b/templates/postgresql.conf-17.j2
@@ -1,0 +1,851 @@
+# {{ ansible_managed }}
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '{{ postgresql_data_directory }}'		# use data in another directory
+					# (change requires restart)
+hba_file = '{{ postgresql_hba_file }}'	# host-based authentication file
+					# (change requires restart)
+ident_file = '{{ postgresql_ident_file }}'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+external_pid_file = '{{ postgresql_external_pid_file }}'			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '{{ postgresql_listen_addresses | join(', ') }}'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+port = {{ postgresql_port }}				# (change requires restart)
+max_connections = {{ postgresql_max_connections }}			# (change requires restart)
+reserved_connections = {{ postgresql_reserved_connections }}		# (change requires restart)
+superuser_reserved_connections = {{ postgresql_superuser_reserved_connections }}	# (change requires restart)
+unix_socket_directories = '{{ postgresql_unix_socket_directories | join(', ') }}'	# comma-separated list of directories
+					# (change requires restart)
+unix_socket_group = '{{ postgresql_unix_socket_group }}'			# (change requires restart)
+unix_socket_permissions = {{ postgresql_unix_socket_permissions }}		# begin with 0 to use octal notation
+					# (change requires restart)
+bonjour = {{ 'on' if postgresql_bonjour else 'off' }}				# advertise server via Bonjour
+					# (change requires restart)
+bonjour_name = '{{ postgresql_bonjour_name }}'			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+tcp_keepalives_idle = {{ postgresql_tcp_keepalives_idle }}		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+tcp_keepalives_interval = {{ postgresql_tcp_keepalives_interval }}		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+tcp_keepalives_count = {{ postgresql_tcp_keepalives_count }}		# TCP_KEEPCNT;
+					# 0 selects the system default
+tcp_user_timeout = {{ postgresql_tcp_user_timeout }}			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+client_connection_check_interval = {{ postgresql_client_connection_check_interval }}	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
+
+# - Authentication -
+
+authentication_timeout = {{ postgresql_authentication_timeout }}		# 1s-600s
+password_encryption = {{ postgresql_password_encryption }}	# scram-sha-256 or md5
+scram_iterations = {{ posgresql_scram_iterations }}
+
+# GSSAPI using Kerberos
+krb_server_keyfile = '{{ postgresql_krb_server_keyfile }}'
+krb_caseins_users = {{ 'on' if postgresql_krb_caseins_users else 'off' }}
+gss_accept_delegation = {{ 'on' if postgresql_gss_accept_delegation else 'off' }}
+
+# - SSL -
+
+ssl = {{ 'on' if postgresql_ssl else 'off' }}
+ssl_ca_file = '{{ postgresql_ssl_ca_file }}'
+ssl_cert_file = '{{ postgresql_ssl_cert_file }}'
+ssl_crl_file = '{{ postgresql_ssl_crl_file }}'
+ssl_crl_dir = '{{ postgresql_ssl_crl_dir }}'
+ssl_key_file = '{{ postgresql_ssl_key_file }}'
+ssl_ciphers = '{{ postgresql_ssl_ciphers | join(':') }}' # allowed SSL ciphers
+ssl_prefer_server_ciphers = {{ 'on' if postgresql_ssl_prefer_server_ciphers else 'off' }}
+ssl_ecdh_curve = '{{ postgresql_ssl_ecdh_curve }}'
+ssl_min_protocol_version = '{{ postgresql_ssl_min_protocol_version }}'
+ssl_max_protocol_version = '{{ postgresql_ssl_max_protocol_version }}'
+ssl_dh_params_file = '{{ postgresql_ssl_dh_params_file }}'
+ssl_passphrase_command = '{{ postgresql_ssl_passphrase_command }}'
+ssl_passphrase_command_supports_reload = {{ 'on' if postgresql_ssl_passphrase_command_supports_reload else 'off' }}
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = {{ postgresql_shared_buffers }}			# min 128kB
+					# (change requires restart)
+huge_pages = {{ postgresql_huge_pages }}			# on, off, or try
+					# (change requires restart)
+huge_page_size = {{ postgresql_huge_page_size }}			# zero for system default
+					# (change requires restart)
+temp_buffers = {{ postgresql_temp_buffers }}			# min 800kB
+max_prepared_transactions = {{ postgresql_max_prepared_transactions }}		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+work_mem = {{ postgresql_work_mem }}				# min 64kB
+hash_mem_multiplier = {{ postgresql_hash_mem_multiplier }}		# 1-1000.0 multiplier on hash table work_mem
+maintenance_work_mem = {{ postgresql_maintenance_work_mem }}		# min 64kB
+autovacuum_work_mem = {{ postgresql_autovacuum_work_mem }}		# min 64kB, or -1 to use maintenance_work_mem
+logical_decoding_work_mem = {{ postgresql_logical_decoding_work_mem }}	# min 64kB
+max_stack_depth = {{ postgresql_max_stack_depth }}			# min 100kB
+shared_memory_type = {{ postgresql_shared_memory_type }}		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = {{ postgresql_dynamic_shared_memory_type }}	# the default is usually the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+min_dynamic_shared_memory = {{ postgresql_min_dynamic_shared_memory }}	# (change requires restart)
+vacuum_buffer_usage_limit = {{ postgres_vacuum_buffer_usage_limit }}	# size of vacuum and analyze buffer access strategy ring;
+					# 0 to disable vacuum buffer access strategy;
+					# range 128kB to 16GB
+
+# SLRU buffers (change requires restart)
+commit_timestamp_buffers = {{ postgresql_commit_timestamp_buffers }}		# memory for pg_commit_ts (0 = auto)
+multixact_offset_buffers = {{ postgresql_multixact_offset_buffers }}		# memory for pg_multixact/offsets
+multixact_member_buffers = {{ postgresql_multixact_member_buffers }}		# memory for pg_multixact/members
+notify_buffers = {{ postgresql_notify_buffers }}			# memory for pg_notify
+serializable_buffers = {{ postgresql_serializable_buffers }}		# memory for pg_serial
+subtransaction_buffers = {{ postgresql_subtransaction_buffers }}		# memory for pg_subtrans (0 = auto)
+transaction_buffers = {{ postgresql_transaction_buffers }}		# memory for pg_xact (0 = auto)
+
+# - Disk -
+
+temp_file_limit = {{ postgresql_temp_file_limit }}			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+max_notify_queue_pages = {{ postgresql_max_notify_queue_pages }}	# limits the number of SLRU pages allocated
+					# for NOTIFY / LISTEN queue
+
+# - Kernel Resources -
+
+max_files_per_process = {{ postgresql_max_files_per_process }}		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+vacuum_cost_delay = {{ postgresql_vacuum_cost_delay }}			# 0-100 milliseconds (0 disables)
+vacuum_cost_page_hit = {{ postgresql_vacuum_cost_page_hit }}		# 0-10000 credits
+vacuum_cost_page_miss = {{ postgresql_vacuum_cost_page_miss }}		# 0-10000 credits
+vacuum_cost_page_dirty = {{ postgresql_vacuum_cost_page_dirty }}		# 0-10000 credits
+vacuum_cost_limit = {{ postgresql_vacuum_cost_limit }}		# 1-10000 credits
+
+# - Background Writer -
+
+bgwriter_delay = {{ postgresql_bgwriter_delay }}			# 10-10000ms between rounds
+bgwriter_lru_maxpages = {{ postgresql_bgwriter_lru_maxpages }}		# max buffers written/round, 0 disables
+bgwriter_lru_multiplier = {{ postgresql_bgwriter_lru_multiplier }}		# 0-10.0 multiplier on buffers scanned/round
+bgwriter_flush_after = {{ postgresql_bgwriter_flush_after }}		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+backend_flush_after = {{ postgresql_backend_flush_after }}		# measured in pages, 0 disables
+effective_io_concurrency = {{ postgresql_effective_io_concurrency }}		# 1-1000; 0 disables prefetching
+maintenance_io_concurrency = {{ postgresql_maintenance_io_concurrency }}	# 1-1000; 0 disables prefetching
+io_combine_limit = {{ postgresql_io_combine_limit }}		# usually 1-32 blocks (depends on OS)
+max_worker_processes = {{ postgresql_max_worker_processes }}		# (change requires restart)
+max_parallel_workers_per_gather = {{ postgresql_max_parallel_workers_per_gather }}	# limited by max_parallel_workers
+max_parallel_maintenance_workers = {{ postgresql_max_parallel_maintenance_workers }}	# limited by max_parallel_workers
+max_parallel_workers = {{ postgresql_max_parallel_workers }}		# number of max_worker_processes that
+					# can be used in parallel operations
+parallel_leader_participation = {{ 'on' if postgresql_parallel_leader_participation else 'off' }}
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = {{ postgresql_wal_level }}			# minimal, replica, or logical
+					# (change requires restart)
+fsync = {{ 'on' if postgresql_fsync else 'off' }}				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+synchronous_commit = {{ postgresql_synchronous_commit }}		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+wal_sync_method = {{ postgresql_wal_sync_method }}		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+full_page_writes = {{ 'on' if postgresql_full_page_writes else 'off' }}			# recover from partial page writes
+wal_log_hints = {{ 'on' if postgresql_wal_log_hints else 'off' }}			# also do full page writes of non-critical updates
+					# (change requires restart)
+wal_compression = {{ 'on' if postgresql_wal_compression else 'off' }}			# enables compression of full-page writes;
+					# off, pglz, lz4, zstd, or on
+wal_init_zero = {{ 'on' if postgresql_wal_init_zero else 'off' }}			# zero-fill new WAL files
+wal_recycle = {{ 'on' if postgresql_wal_recycle else 'off' }}			# recycle WAL files
+wal_buffers = {{ postgresql_wal_buffers }}			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+wal_writer_delay = {{ postgresql_wal_writer_delay }}		# 1-10000 milliseconds
+wal_writer_flush_after = {{ postgresql_wal_writer_flush_after }}		# measured in pages, 0 disables
+wal_skip_threshold = {{ postgresql_wal_skip_threshold }}
+
+commit_delay = {{ postgresql_commit_delay }}			# range 0-100000, in microseconds
+commit_siblings = {{ postgresql_commit_siblings }}			# range 1-1000
+
+# - Checkpoints -
+
+checkpoint_timeout = {{ postgresql_checkpoint_timeout }}		# range 30s-1d
+checkpoint_completion_target = {{ postgresql_checkpoint_completion_target }}	# checkpoint target duration, 0.0 - 1.0
+checkpoint_flush_after = {{ postgresql_checkpoint_flush_after }}		# measured in pages, 0 disables
+checkpoint_warning = {{ postgresql_checkpoint_warning }}		# 0 disables
+max_wal_size = {{ postgresql_max_wal_size }}
+min_wal_size = {{ postgresql_min_wal_size }}
+
+# - Prefetching during recovery -
+
+recovery_prefetch = {{ postgresql_recovery_prefetch }}		# prefetch pages referenced in the WAL?
+wal_decode_buffer_size = {{ postgresql_wal_decode_buffer_size }}		# lookahead window used for prefetching
+					# (change requires restart)
+
+# - Archiving -
+
+archive_mode = {{ 'on' if ( postgresql_archive_mode | bool == true or postgresql_archive_mode == 'on' ) else ( 'always' if postgresql_archive_mode == 'always' else 'off' ) }}		# enables archiving; off, on, or always
+				# (change requires restart)
+archive_library = '{{ postgresql_archive_library }}'		# library to use to archive a logfile segment
+				# (empty string indicates archive_command should
+				# be used)
+archive_command = '{{ postgresql_archive_command }}'		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+archive_timeout = {{ postgresql_archive_timeout }}		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+restore_command = '{{ postgresql_restore_command }}'		# command to use to restore an archived logfile segment
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+archive_cleanup_command = '{{ postgresql_archive_cleanup_command }}'	# command to execute at every restartpoint
+recovery_end_command = '{{ postgresql_recovery_end_command }}'	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+recovery_target = '{{ postgresql_recovery_target }}'		# 'immediate' to end recovery as soon as a
+                                # consistent state is reached
+				# (change requires restart)
+recovery_target_name = '{{ postgresql_recovery_target_name }}'	# the named restore point to which recovery will proceed
+				# (change requires restart)
+recovery_target_time = '{{ postgresql_recovery_target_time }}'	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+recovery_target_xid = '{{ postgresql_recovery_target_xid }}'	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+recovery_target_lsn = '{{ postgresql_recovery_target_lsn }}'	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+recovery_target_inclusive = {{ 'on' if postgresql_recovery_target_inclusive else 'off' }} # Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+recovery_target_timeline = '{{ postgresql_recovery_target_timeline }}'	# 'current', 'latest', or timeline ID
+				# (change requires restart)
+recovery_target_action = '{{ postgresql_recovery_target_action }}'	# 'pause', 'promote', 'shutdown'
+				# (change requires restart)
+
+# - WAL Summarization -
+
+summarize_wal = {{ 'on' if postgresql_summarize_wal else 'off' }}		# run WAL summarizer process?
+wal_summary_keep_time = '{{ postgresql_wal_summary_keep_time }}'	# when to remove old summary files, 0 = never
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+max_wal_senders = {{ postgresql_max_wal_senders }}		# max number of walsender processes
+				# (change requires restart)
+max_replication_slots = {{ postgresql_max_replication_slots }}	# max number of replication slots
+				# (change requires restart)
+wal_keep_size = {{ postgresql_wal_keep_size }}		# in megabytes; 0 disables
+max_slot_wal_keep_size = {{ postgresql_max_slot_wal_keep_size }}	# in megabytes; -1 disables
+wal_sender_timeout = {{ postgresql_wal_sender_timeout }}	# in milliseconds; 0 disables
+track_commit_timestamp = {{ 'on' if postgresql_track_commit_timestamp else 'off' }}	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+synchronous_standby_names = '{% if postgresql_synchronous_standby_names != [] %}{% if postgresql_synchronous_standby_choose_sync != "" and postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_choose_sync }} {% endif %}{% if postgresql_synchronous_standby_num_sync != "" %}{{ postgresql_synchronous_standby_num_sync }} ({% endif %}"{{ postgresql_synchronous_standby_names | join('\",\"') }}"{% if postgresql_synchronous_standby_num_sync != "" %}){% endif %}{% endif %}'	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+synchronized_standby_slots = '{{ postgresql_synchronized_standby_slots }}'	# streaming replication standby server slot
+				# names that logical walsender processes will wait for
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+primary_conninfo = '{{ postgresql_primary_conninfo }}'			# connection string to sending server
+primary_slot_name = '{{ postgresql_primary_slot_name }}'			# replication slot on sending server
+hot_standby = {{ 'on' if postgresql_hot_standby else 'off' }}			# "off" disallows queries during recovery
+					# (change requires restart)
+max_standby_archive_delay = {{ postgresql_max_standby_archive_delay }}	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+max_standby_streaming_delay = {{ postgresql_max_standby_streaming_delay }}	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+wal_receiver_create_temp_slot = {{ 'on' if postgresql_wal_receiver_create_temp_slot else 'off' }}	# create temp slot if primary_slot_name
+					# is not set
+wal_receiver_status_interval = {{ postgresql_wal_receiver_status_interval }}	# send replies at least this often
+					# 0 disables
+hot_standby_feedback = {{ 'on' if postgresql_hot_standby_feedback else 'off' }}		# send info from standby to prevent
+					# query conflicts
+wal_receiver_timeout = {{ postgresql_wal_receiver_timeout }}		# time that receiver waits for
+					# communication from primary
+					# in milliseconds; 0 disables
+wal_retrieve_retry_interval = {{ postgresql_wal_retrieve_retry_interval }}	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+recovery_min_apply_delay = {{ postgresql_recovery_min_apply_delay }}		# minimum delay for applying changes during recovery
+sync_replication_slots = {{ 'on' if postgresql_sync_replication_slots else 'off' }}		# enables slot synchronization on the physical standby from the primary
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+max_logical_replication_workers = {{ postgresql_max_logical_replication_workers }}	# taken from max_worker_processes
+					# (change requires restart)
+max_sync_workers_per_subscription = {{ postgresql_max_sync_workers_per_subscription }}	# taken from max_logical_replication_workers
+max_parallel_apply_workers_per_subscription = {{ postgresql_max_parallel_apply_workers_per_subscription }}	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+enable_async_append = {{ 'on' if postgresql_enable_async_append else 'off' }}
+enable_bitmapscan = {{ 'on' if postgresql_enable_bitmapscan else 'off' }}
+enable_gathermerge = {{ 'on' if postgresql_enable_gathermerge else 'off' }}
+enable_hashagg = {{ 'on' if postgresql_enable_hashagg else 'off' }}
+enable_hashjoin = {{ 'on' if postgresql_enable_hashjoin else 'off' }}
+enable_incremental_sort = {{ 'on' if postgresql_enable_incremental_sort else 'off' }}
+enable_indexscan = {{ 'on' if postgresql_enable_indexscan else 'off' }}
+enable_indexonlyscan = {{ 'on' if postgresql_enable_indexonlyscan else 'off' }}
+enable_material = {{ 'on' if postgresql_enable_material else 'off' }}
+enable_memoize = {{ 'on' if postgresql_enable_memoize else 'off' }}
+enable_mergejoin = {{ 'on' if postgresql_enable_mergejoin else 'off' }}
+enable_nestloop = {{ 'on' if postgresql_enable_nestloop else 'off'  }}
+enable_parallel_append = {{ 'on' if postgresql_enable_parallel_append else 'off' }}
+enable_parallel_hash = {{ 'on' if postgresql_enable_parallel_hash else 'off' }}
+enable_partition_pruning = {{ 'on' if postgresql_enable_partition_pruning else 'off' }}
+enable_partitionwise_join = {{ 'on' if postgresql_enable_partitionwise_join else 'off' }}
+enable_partitionwise_aggregate = {{ 'on' if postgresql_enable_partitionwise_aggregate else 'off' }}
+enable_presorted_aggregate = {{ 'on' if postgres_enable_presorted_aggregate else 'off' }}
+enable_seqscan = {{ 'on' if postgresql_enable_seqscan else 'off' }}
+enable_sort = {{ 'on' if postgresql_enable_sort else 'off' }}
+enable_tidscan = {{ 'on' if postgresql_enable_tidscan else 'off' }}
+enable_group_by_reordering = {{ 'on' if postgresql_enable_group_by_reordering else 'off' }}
+
+# - Planner Cost Constants -
+
+seq_page_cost = {{ postgresql_seq_page_cost }}			# measured on an arbitrary scale
+random_page_cost = {{ postgresql_random_page_cost }}			# same scale as above
+cpu_tuple_cost = {{ postgresql_cpu_tuple_cost }}			# same scale as above
+cpu_index_tuple_cost = {{ postgresql_cpu_index_tuple_cost }}		# same scale as above
+cpu_operator_cost = {{ postgresql_cpu_operator_cost }}		# same scale as above
+parallel_setup_cost = {{ postgresql_parallel_setup_cost }}	# same scale as above
+parallel_tuple_cost = {{ postgresql_parallel_tuple_cost }}		# same scale as above
+min_parallel_table_scan_size = {{ postgresql_min_parallel_table_scan_size }}
+min_parallel_index_scan_size = {{ postgresql_min_parallel_index_scan_size }}
+effective_cache_size = {{ postgresql_effective_cache_size }}
+
+jit_above_cost = {{ postgresql_jit_above_cost }}		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+jit_inline_above_cost = {{ postgresql_jit_inline_above_cost }}		# inline small functions if query is
+					# more expensive than this; -1 disables
+jit_optimize_above_cost = {{ postgresql_jit_optimize_above_cost }}	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+# - Genetic Query Optimizer -
+
+geqo = {{ 'on' if postgresql_geqo else 'off' }}
+geqo_threshold = {{ postgresql_geqo_threshold }}
+geqo_effort = {{ postgresql_geqo_effort }}			# range 1-10
+geqo_pool_size = {{ postgresql_geqo_pool_size }}			# selects default based on effort
+geqo_generations = {{ postgresql_geqo_generations }}			# selects default based on effort
+geqo_selection_bias = {{ postgresql_geqo_selection_bias }}		# range 1.5-2.0
+geqo_seed = {{ postgresql_geqo_seed }}			# range 0.0-1.0
+
+# - Other Planner Options -
+
+default_statistics_target = {{ postgresql_default_statistics_target }}	# range 1-10000
+constraint_exclusion = {{ postgresql_constraint_exclusion }}	# on, off, or partition
+cursor_tuple_fraction = {{ postgresql_cursor_tuple_fraction }}		# range 0.0-1.0
+from_collapse_limit = {{ postgresql_from_collapse_limit }}
+jit = {{ 'on' if postgresql_jit else 'off' }}				# allow JIT compilation
+join_collapse_limit = {{ postgresql_join_collapse_limit }}		# 1 disables collapsing of explicit
+					# JOIN clauses
+plan_cache_mode = {{ postgresql_plan_cache_mode }}			# auto, force_generic_plan or
+					# force_custom_plan
+recursive_worktable_factor = {{ postgresql_recursive_worktable_factor }}	# range 0.001-1000000
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+log_destination = '{{ postgresql_log_destination }}'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# csvlog and jsonlog require
+					# logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = {{ 'on' if postgresql_logging_collector else 'off' }}			# Enable capturing of stderr, jsonlog,
+					# and csvlog into log files. Required
+					# to be on for csvlogs and jsonlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '{{ postgresql_log_directory }}'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = '{{ postgresql_log_filename }}'	# log file name pattern,
+					# can include strftime() escapes
+log_file_mode = {{ postgresql_log_file_mode }}			# creation mode for log files,
+					# begin with 0 to use octal notation
+log_rotation_age = {{ postgresql_log_rotation_age }}			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+log_rotation_size = {{ postgresql_log_rotation_size }}			# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+log_truncate_on_rotation = {{ 'on' if postgresql_log_truncate_on_rotation else 'off' }}		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+
+# These are relevant when logging to syslog:
+syslog_facility = '{{ postgresql_syslog_facility }}'
+syslog_ident = '{{ postgresql_syslog_ident }}'
+syslog_sequence_numbers = {{ 'on' if postgresql_syslog_sequence_numbers else 'off' }}
+syslog_split_messages = {{ 'on' if postgresql_syslog_split_messages else 'off' }}
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+event_source = '{{ postgresql_event_source }}'
+
+# - When to Log -
+
+log_min_messages = {{ postgresql_log_min_messages }}		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+log_min_error_statement = {{ postgresql_log_min_error_statement }}	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+log_min_duration_statement = {{ postgresql_log_min_duration_statement }}	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+log_min_duration_sample = {{ postgresql_log_min_duration_sample }}		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+log_statement_sample_rate = {{ postgresql_log_statement_sample_rate }}	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+log_transaction_sample_rate = {{ postgresql_log_transaction_sample_rate }}	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+log_startup_progress_interval = {{ postgresql_log_startup_progress_interval }}	# Time between progress updates for
+					# long-running startup operations.
+					# 0 disables the feature, > 0 indicates
+					# the interval in milliseconds.
+
+# - What to Log -
+
+debug_print_parse = {{ 'on' if postgresql_debug_print_parse else 'off' }}
+debug_print_rewritten = {{ 'on' if postgresql_debug_print_rewritten else 'off' }}
+debug_print_plan = {{ 'on' if postgresql_debug_print_plan else 'off' }}
+debug_pretty_print = {{ 'on' if postgresql_debug_pretty_print else 'off' }}
+log_autovacuum_min_duration = {{ postgresql_log_autovacuum_min_duration }}	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+log_checkpoints = {{ 'on' if postgresql_log_checkpoints else 'off' }}
+log_connections = {{ 'on' if postgresql_log_connections else 'off' }}
+log_disconnections = {{ 'on' if postgresql_log_disconnections else 'off' }}
+log_duration = {{ 'on' if postgresql_log_duration else 'off' }}
+log_error_verbosity = {{ postgresql_log_error_verbosity }}		# terse, default, or verbose messages
+log_hostname = {{ 'on' if postgresql_log_hostname else 'off' }}
+log_line_prefix = '{{ postgresql_log_line_prefix }}'		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+log_lock_waits = {{ 'on' if postgresql_log_lock_waits else 'off' }}			# log lock waits >= deadlock_timeout
+log_recovery_conflict_waits = {{ 'on' if postgresql_log_recovery_conflict_waits else 'off' }}	# log standby recovery conflict waits
+					# >= deadlock_timeout
+log_parameter_max_length = {{ postgresql_log_parameter_max_length }}		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+log_parameter_max_length_on_error = {{ postgresql_log_parameter_max_length_on_error }}	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+log_statement = '{{ postgresql_log_statement }}'			# none, ddl, mod, all
+log_replication_commands = {{ 'on' if postgresql_log_replication_commands else 'off' }}
+log_temp_files = {{ postgresql_log_temp_files }}			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = '{{ postgresql_log_timezone }}'
+
+# - Process Title -
+
+cluster_name = '{{ postgresql_cluster_name }}'			# added to process titles if nonempty
+					# (change requires restart)
+update_process_title = {{ 'on' if postgresql_update_process_title else 'off' }}
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Cumulative Query and Index Statistics -
+
+track_activities = {{ 'on' if postgresql_track_activities else 'off' }}
+track_activity_query_size = {{ postgresql_track_activity_query_size }}	# (change requires restart)
+track_counts = {{ 'on' if postgresql_track_counts else 'off' }}
+track_io_timing = {{ 'on' if postgresql_track_io_timing else 'off' }}
+track_wal_io_timing = {{ 'on' if postgresql_track_wal_io_timing else 'off' }}
+track_functions = {{ postgresql_track_functions }}			# none, pl, all
+stats_fetch_consistency = {{ postgresql_stats_fetch_consistency }}	# cache, none, snapshot
+
+
+# - Monitoring -
+
+compute_query_id = {{ postgresql_compute_query_id }}
+log_statement_stats = {{ 'on' if postgresql_log_statement_stats else 'off' }}
+log_parser_stats = {{ 'on' if postgresql_log_parser_stats else 'off' }}
+log_planner_stats = {{ 'on' if postgresql_log_planner_stats else 'off' }}
+log_executor_stats = {{ 'on' if postgresql_log_executor_stats else 'off' }}
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+autovacuum = {{ 'on' if postgresql_autovacuum else 'off' }}			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+autovacuum_max_workers = {{ postgresql_autovacuum_max_workers }}		# max number of autovacuum subprocesses
+					# (change requires restart)
+autovacuum_naptime = {{ postgresql_autovacuum_naptime }}		# time between autovacuum runs
+autovacuum_vacuum_threshold = {{ postgresql_autovacuum_vacuum_threshold }}	# min number of row updates before
+					# vacuum
+autovacuum_vacuum_insert_threshold = {{ postgresql_autovacuum_vacuum_insert_threshold }}	# min number of row inserts
+					# before vacuum; -1 disables insert
+					# vacuums
+autovacuum_analyze_threshold = {{ postgresql_autovacuum_analyze_threshold }}	# min number of row updates before
+					# analyze
+autovacuum_vacuum_scale_factor = {{ postgresql_autovacuum_vacuum_scale_factor }}	# fraction of table size before vacuum
+autovacuum_vacuum_insert_scale_factor = {{ postgresql_autovacuum_vacuum_insert_scale_factor }}	# fraction of inserts over table
+					# size before insert vacuum
+autovacuum_analyze_scale_factor = {{ postgresql_autovacuum_analyze_scale_factor }}	# fraction of table size before analyze
+autovacuum_freeze_max_age = {{ postgresql_autovacuum_freeze_max_age }}	# maximum XID age before forced vacuum
+					# (change requires restart)
+autovacuum_multixact_freeze_max_age = {{ postgresql_autovacuum_multixact_freeze_max_age }}	# maximum multixact age
+					# before forced vacuum
+					# (change requires restart)
+autovacuum_vacuum_cost_delay = {{ postgresql_autovacuum_vacuum_cost_delay }}	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+autovacuum_vacuum_cost_limit = {{ postgresql_autovacuum_vacuum_cost_limit }}	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+client_min_messages = {{ postgresql_client_min_messages }}		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+search_path = '{{ postgresql_search_path | join(', ') }}'	# schema names
+row_security = {{ 'on' if postgresql_row_security else 'off' }}
+default_table_access_method = '{{ postgresql_default_table_access_method }}'
+default_tablespace = '{{ postgresql_default_tablespace }}'		# a tablespace name, '' uses the default
+default_toast_compression = '{{ postgresql_default_toast_compression }}' # 'pglz' or 'lz4'
+temp_tablespaces = '{{ postgresql_temp_tablespaces | join(', ') }}'			# a list of tablespace names, '' uses
+					# only default tablespace
+check_function_bodies = {{ 'on' if postgresql_check_function_bodies else 'off' }}
+default_transaction_isolation = '{{ postgresql_default_transaction_isolation }}'
+default_transaction_read_only = {{ 'on' if postgresql_default_transaction_read_only else 'off' }}
+default_transaction_deferrable = {{ 'on' if postgresql_default_transaction_deferrable else 'off' }}
+session_replication_role = '{{ postgresql_session_replication_role }}'
+statement_timeout = {{ postgresql_statement_timeout }}			# in milliseconds, 0 is disabled
+transaction_timeout = {{ postgresql_transaction_timeout }}			# in milliseconds, 0 is disabled
+lock_timeout = {{ postgresql_lock_timeout }}			# in milliseconds, 0 is disabled
+idle_in_transaction_session_timeout = {{ postgresql_idle_in_transaction_session_timeout }}	# in milliseconds, 0 is disabled
+idle_session_timeout = {{ postgresql_idle_session_timeout }}		# in milliseconds, 0 is disabled
+vacuum_freeze_table_age = {{ postgresql_vacuum_freeze_table_age }}
+vacuum_freeze_min_age = {{ postgresql_vacuum_freeze_min_age }}
+vacuum_failsafe_age = {{ postgresql_vacuum_failsafe_age }}
+vacuum_multixact_freeze_table_age = {{ postgresql_vacuum_multixact_freeze_table_age }}
+vacuum_multixact_freeze_min_age = {{ postgresql_vacuum_multixact_freeze_min_age }}
+vacuum_multixact_failsafe_age = {{ postgresql_vacuum_multixact_failsafe_age }}
+bytea_output = '{{ postgresql_bytea_output }}'			# hex, escape
+xmlbinary = '{{ postgresql_xmlbinary }}'
+xmloption = '{{ postgresql_xmloption }}'
+gin_pending_list_limit = {{ postgresql_gin_pending_list_limit }}
+createrole_self_grant = '{{ postgresql_createrole_self_grant }}'		# set and/or inherit
+event_triggers = {{ 'on' if postgresql_event_triggers else 'off' }}
+
+# - Locale and Formatting -
+
+datestyle = '{{ postgresql_datestyle | join(', ') }}'
+intervalstyle = '{{ postgresql_intervalstyle }}'
+timezone = '{{ postgresql_timezone }}'
+timezone_abbreviations = '{{ postgresql_timezone_abbreviations }}'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+extra_float_digits = {{ postgresql_extra_float_digits }}			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+{% if not postgresql_client_encoding %}
+#client_encoding = sql_ascii		# actually, defaults to database
+{% else %}
+client_encoding = {{ postgresql_client_encoding }}		# actually, defaults to database
+{% endif %}
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = '{{ postgresql_lc_messages }}'			# locale for system error message
+					# strings
+lc_monetary = '{{ postgresql_lc_monetary }}'			# locale for monetary formatting
+lc_numeric = '{{ postgresql_lc_numeric }}'			# locale for number formatting
+lc_time = '{{ postgresql_lc_time }}'				# locale for time formatting
+
+icu_validation_level = {{ postgresql_icu_validation_level }}		# report ICU locale validation
+					# errors at the given level
+
+# default configuration for text search
+default_text_search_config = '{{ postgresql_default_text_search_config }}'
+
+# - Shared Library Preloading -
+
+local_preload_libraries = '{{ postgresql_local_preload_libraries | join(', ') }}'
+session_preload_libraries = '{{ postgresql_session_preload_libraries | join(', ') }}'
+shared_preload_libraries = '{{ postgresql_shared_preload_libraries | join(', ') }}'	# (change requires restart)
+jit_provider = '{{ postgresql_jit_provider }}'		# JIT library to use
+
+# - Other Defaults -
+
+dynamic_library_path = '{{ postgresql_dynamic_library_path }}'
+{% if postgresql_extension_destdir is defined and ansible_os_family == 'Debian' %}
+extension_destdir = '{{ postgresql_extension_destdir }}'			# prepend path when loading extensions
+					# and shared objects (added by Debian)
+{% endif %}
+gin_fuzzy_search_limit = {{ postgresql_gin_fuzzy_search_limit }}
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+deadlock_timeout = {{ postgresql_deadlock_timeout }}
+max_locks_per_transaction = {{ postgresql_max_locks_per_transaction }}		# min 10
+					# (change requires restart)
+max_pred_locks_per_transaction = {{ postgresql_max_pred_locks_per_transaction }}	# min 10
+					# (change requires restart)
+max_pred_locks_per_relation = {{ postgresql_max_pred_locks_per_relation }}	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+max_pred_locks_per_page = {{ postgresql_max_pred_locks_per_page }}            # min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+array_nulls = {{ 'on' if postgresql_array_nulls else 'off' }}
+backslash_quote = {{ postgresql_backslash_quote }}	# on, off, or safe_encoding
+escape_string_warning = {{ 'on' if postgresql_escape_string_warning else 'off' }}
+lo_compat_privileges = {{ 'on' if postgresql_lo_compat_privileges else 'off' }}
+quote_all_identifiers = {{ 'on' if postgresql_quote_all_identifiers else 'off' }}
+standard_conforming_strings = {{ 'on' if postgresql_standard_conforming_strings else 'off' }}
+synchronize_seqscans = {{ 'on' if postgresql_synchronize_seqscans else 'off' }}
+
+# - Other Platforms and Clients -
+
+transform_null_equals = {{ 'on' if postgresql_transform_null_equals else 'off' }}
+allow_alter_system = {{ 'on' if postgresql_allow_alter_system else 'off' }}
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+exit_on_error = {{ 'on' if postgresql_exit_on_error else 'off' }}			# terminate session on any error?
+restart_after_crash = {{ 'on' if postgresql_restart_after_crash else 'off' }}		# reinitialize after backend crash?
+data_sync_retry = {{ 'on' if postgresql_data_sync_retry else 'off' }}			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+recovery_init_sync_method = {{ postgresql_recovery_init_sync_method }}	# fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+include_dir = '{{ postgresql_include_dir }}'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+{{ '#' if not postgresql_include_if_exists | bool else '' }}include_if_exists = '{{ postgresql_include_if_exists }}'		# include file only if it exists
+{{ '#' if not postgresql_include | bool else '' }}include = '{{ postgresql_include }}'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/templates/postgresql.conf-17.orig
+++ b/templates/postgresql.conf-17.orig
@@ -1,0 +1,844 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+#data_directory = 'ConfigDir'		# use data in another directory
+					# (change requires restart)
+#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+#listen_addresses = 'localhost'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+#port = 5432				# (change requires restart)
+#max_connections = 100			# (change requires restart)
+#reserved_connections = 0		# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+#unix_socket_directories = '/tmp'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+#client_connection_check_interval = 0	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
+
+# - Authentication -
+
+#authentication_timeout = 1min		# 1s-600s
+#password_encryption = scram-sha-256	# scram-sha-256 or md5
+#scram_iterations = 4096
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+#gss_accept_delegation = off
+
+# - SSL -
+
+#ssl = off
+#ssl_ca_file = ''
+#ssl_cert_file = 'server.crt'
+#ssl_crl_file = ''
+#ssl_crl_dir = ''
+#ssl_key_file = 'server.key'
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'	# allowed SSL ciphers
+#ssl_prefer_server_ciphers = on
+#ssl_ecdh_curve = 'prime256v1'
+#ssl_min_protocol_version = 'TLSv1.2'
+#ssl_max_protocol_version = ''
+#ssl_dh_params_file = ''
+#ssl_passphrase_command = ''
+#ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+#shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#huge_page_size = 0			# zero for system default
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+#max_prepared_transactions = 0		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+#work_mem = 4MB				# min 64kB
+#hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
+#maintenance_work_mem = 64MB		# min 64kB
+#autovacuum_work_mem = -1		# min 64kB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+#dynamic_shared_memory_type = posix	# the default is usually the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+#min_dynamic_shared_memory = 0MB	# (change requires restart)
+#vacuum_buffer_usage_limit = 2MB	# size of vacuum and analyze buffer access strategy ring;
+					# 0 to disable vacuum buffer access strategy;
+					# range 128kB to 16GB
+
+# SLRU buffers (change requires restart)
+#commit_timestamp_buffers = 0		# memory for pg_commit_ts (0 = auto)
+#multixact_offset_buffers = 16		# memory for pg_multixact/offsets
+#multixact_member_buffers = 32		# memory for pg_multixact/members
+#notify_buffers = 16			# memory for pg_notify
+#serializable_buffers = 32		# memory for pg_serial
+#subtransaction_buffers = 0		# memory for pg_subtrans (0 = auto)
+#transaction_buffers = 0		# memory for pg_xact (0 = auto)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+#max_notify_queue_pages = 1048576	# limits the number of SLRU pages allocated
+					# for NOTIFY / LISTEN queue
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 2		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 0		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#backend_flush_after = 0		# measured in pages, 0 disables
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#io_combine_limit = 128kB		# usually 1-32 blocks (depends on OS)
+#max_worker_processes = 8		# (change requires restart)
+#max_parallel_workers_per_gather = 2	# limited by max_parallel_workers
+#max_parallel_maintenance_workers = 2	# limited by max_parallel_workers
+#max_parallel_workers = 8		# number of max_worker_processes that
+					# can be used in parallel operations
+#parallel_leader_participation = on
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+#wal_level = replica			# minimal, replica, or logical
+					# (change requires restart)
+#fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+#synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+#full_page_writes = on			# recover from partial page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_compression = off			# enables compression of full-page writes;
+					# off, pglz, lz4, zstd, or on
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min		# range 30s-1d
+#checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_flush_after = 0		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+#max_wal_size = 1GB
+#min_wal_size = 80MB
+
+# - Prefetching during recovery -
+
+#recovery_prefetch = try	# prefetch pages referenced in the WAL?
+#wal_decode_buffer_size = 512kB	# lookahead window used for prefetching
+				# (change requires restart)
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_library = ''		# library to use to archive a WAL file
+				# (empty string indicates archive_command should
+				# be used)
+#archive_command = ''		# command to use to archive a WAL file
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a WAL file switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived WAL file
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+				# consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on	# Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+					# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+					# (change requires restart)
+
+# - WAL Summarization -
+
+#summarize_wal = off		# run WAL summarizer process?
+#wal_summary_keep_time = '10d'	# when to remove old summary files, 0 = never
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+#max_wal_senders = 10		# max number of walsender processes
+				# (change requires restart)
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+#max_slot_wal_keep_size = -1	# in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#synchronized_standby_slots = ''	# streaming replication standby server slot
+				# names that logical walsender processes will wait for
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+#hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from primary
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+#sync_replication_slots = off		# enables slot synchronization on the physical standby from the primary
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+#max_parallel_apply_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_async_append = on
+#enable_bitmapscan = on
+#enable_gathermerge = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_incremental_sort = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_memoize = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_presorted_aggregate = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+#enable_group_by_reordering = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_setup_cost = 1000.0		# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+#effective_cache_size = 4GB
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#jit = on				# allow JIT compilation
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+#recursive_worktable_factor = 10.0	# range 0.001-1000000
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+#log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# csvlog and jsonlog require
+					# logging_collector to be on.
+
+# This is used when logging to stderr:
+#logging_collector = off		# Enable capturing of stderr, jsonlog,
+					# and csvlog into log files. Required
+					# to be on for csvlogs and jsonlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'log'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
+							# can include strftime() escapes
+#log_file_mode = 0600			# creation mode for log files,
+					# begin with 0 to use octal notation
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+#log_startup_progress_interval = 10s	# Time between progress updates for
+					# long-running startup operations.
+					# 0 disables the feature, > 0 indicates
+					# the interval in milliseconds.
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_autovacuum_min_duration = 10min	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#log_checkpoints = on
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = '%m [%p] '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off	# log standby recovery conflict waits
+					# >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+#log_timezone = 'GMT'
+
+# - Process Title -
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Cumulative Query and Index Statistics -
+
+#track_activities = on
+#track_activity_query_size = 1024	# (change requires restart)
+#track_counts = on
+#track_io_timing = off
+#track_wal_io_timing = off
+#track_functions = none			# none, pl, all
+#stats_fetch_consistency = cache	# cache, none, snapshot
+
+
+# - Monitoring -
+
+#compute_query_id = auto
+#log_statement_stats = off
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+						# before vacuum; -1 disables insert
+						# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+						# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+							# before forced vacuum
+							# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+#row_security = on
+#default_table_access_method = 'heap'
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'	# 'pglz' or 'lz4'
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0				# in milliseconds, 0 is disabled
+#transaction_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0				# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#idle_session_timeout = 0			# in milliseconds, 0 is disabled
+#vacuum_freeze_table_age = 150000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_pending_list_limit = 4MB
+#createrole_self_grant = ''		# set and/or inherit
+#event_triggers = on
+
+# - Locale and Formatting -
+
+#datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+#timezone = 'GMT'
+#timezone_abbreviations = 'Default'	# Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+#extra_float_digits = 1			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+#lc_messages = ''			# locale for system error message
+					# strings
+#lc_monetary = 'C'			# locale for monetary formatting
+#lc_numeric = 'C'			# locale for number formatting
+#lc_time = 'C'				# locale for time formatting
+
+#icu_validation_level = warning		# report ICU locale validation
+					# errors at the given level
+
+# default configuration for text search
+#default_text_search_config = 'pg_catalog.simple'
+
+# - Shared Library Preloading -
+
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+#shared_preload_libraries = ''		# (change requires restart)
+#jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#extension_destdir = ''			# prepend path when loading extensions
+					# and shared objects (added by Debian)
+#gin_fuzzy_search_limit = 0
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2		# min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+#allow_alter_system = on
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+#recovery_init_sync_method = fsync	# fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here

--- a/vars/postgresql_17.yml
+++ b/vars/postgresql_17.yml
@@ -1,0 +1,4 @@
+---
+# PostgreSQL vars for v17
+
+# None yet. Add them here if needed.


### PR DESCRIPTION
## Description
The ansible role [ANXS/postgresql](https://github.com/ANXS/postgresql) on which our fork is based, does not yet manage the latest version of postgresql ([17.0](https://www.postgresql.org/docs/release/17.0/), released on 2024/09/26, followed on 2024/11/14 by [17.1](https://www.postgresql.org/docs/release/17.1/), and [17.2](https://www.postgresql.org/docs/release/17.2/) on 2024/11/21).
Due to lack of time, the idea of ​​this PR is not to manage the bump as rigorously as if it were to propose it immediately in the source role, but at least to be able to allow us to bump our instances to postgresql 17. When possible, we can consider making the missing modifications to propose the PR in the source role.

## Tests
PR already used to provision several of our postgresql instances in version 17 :white_check_mark: 